### PR TITLE
Bj0rnen/total segment count

### DIFF
--- a/src/main/java/com/spotify/reaper/core/RepairSegment.java
+++ b/src/main/java/com/spotify/reaper/core/RepairSegment.java
@@ -8,8 +8,8 @@ public class RepairSegment {
   private Long id;
   private final ColumnFamily columnFamily;
   private final long runID;
-  private final BigInteger startToken;
-  private final BigInteger endToken;
+  private final BigInteger startToken; // closed/inclusive
+  private final BigInteger endToken; // open/exclusive
   private final State state;
   private final DateTime startTime;
   private final DateTime endTime;
@@ -128,6 +128,6 @@ public class RepairSegment {
 
   @Override
   public String toString() {
-    return String.format("(%s,%s)", startToken.toString(), endToken.toString());
+    return String.format("[%s,%s)", startToken.toString(), endToken.toString());
   }
 }

--- a/src/test/java/com/spotify/reaper/service/SegmentGeneratorTest.java
+++ b/src/test/java/com/spotify/reaper/service/SegmentGeneratorTest.java
@@ -19,80 +19,61 @@ public class SegmentGeneratorTest {
 
   @Test
   public void testGenerateSegments() throws Exception {
-    /*
-    List<String> tokenStrings = Lists.newArrayList("0", "1",
-                                             "56713727820156410577229101238628035242", "56713727820156410577229101238628035243",
-                                             "113427455640312821154458202477256070484", "113427455640312821154458202477256070485");
-    List<BigInteger> tokens = Lists.transform(tokenStrings, new Function<String, BigInteger>() {
-      @Nullable
-      @Override
-      public BigInteger apply(@Nullable String s) {
-        return new BigInteger(s);
-      }
-    });
+    List<BigInteger> tokens = Lists.transform(
+        Lists.newArrayList(
+            "0", "1",
+            "56713727820156410577229101238628035242", "56713727820156410577229101238628035243",
+            "113427455640312821154458202477256070484", "113427455640312821154458202477256070485"),
+        new Function<String, BigInteger>() {
+          @Nullable
+          @Override
+          public BigInteger apply(@Nullable String s) {
+            return new BigInteger(s);
+          }
+        }
+    );
 
     SegmentGenerator generator = new SegmentGenerator("foo.bar.RandomPartitioner");
-    List<RepairSegment> segments = generator.generateSegments(3, tokens);
-    assertEquals(11, segments.size());
-    assertEquals("(0,1)", segments.get(0).toString());
-    assertEquals("(1,18904575940052136859076367079542678415)", segments.get(1).toString());
-    assertEquals("(18904575940052136859076367079542678415,37809151880104273718152734159085356829)",
-                 segments.get(2).toString());
-    assertEquals("(37809151880104273718152734159085356829,56713727820156410577229101238628035242)",
-                 segments.get(3).toString());
-    assertEquals("(56713727820156410577229101238628035242,75618303760208547436305468318170713657)",
-                 segments.get(4).toString());
-    assertEquals("(75618303760208547436305468318170713657,94522879700260684295381835397713392072)",
+    List<RepairSegment> segments = generator.generateSegments(10, tokens);
+    assertEquals(15, segments.size());
+    assertEquals("[0,1)",
+                 segments.get(0).toString());
+    assertEquals("[56713727820156410577229101238628035242,56713727820156410577229101238628035243)",
                  segments.get(5).toString());
-    assertEquals("(94522879700260684295381835397713392072,113427455640312821154458202477256070484)",
-                 segments.get(6).toString());
-    assertEquals("(113427455640312821154458202477256070484,113427455640312821154458202477256070485)",
-                 segments.get(7).toString());
-    assertEquals("(113427455640312821154458202477256070485,132332031580364958013534569556798748900)",
-                 segments.get(8).toString());
-    assertEquals("(132332031580364958013534569556798748900,151236607520417094872610936636341427315)",
-                 segments.get(9).toString());
-    assertEquals("(151236607520417094872610936636341427315,0)", segments.get(10).toString());
+    assertEquals("[113427455640312821154458202477256070484,113427455640312821154458202477256070485)",
+                 segments.get(10).toString());
 
-    tokenStrings = Lists.newArrayList("5", "6",
-                                "56713727820156410577229101238628035242", "56713727820156410577229101238628035242",
-                                "113427455640312821154458202477256070484", "113427455640312821154458202477256070485");
-    tokens = Lists.transform(tokenStrings, new Function<String, BigInteger>() {
-      @Nullable
-      @Override
-      public BigInteger apply(@Nullable String s) {
-        return new BigInteger(s);
-      }
-    });
 
-    generator = new SegmentGenerator("foo.bar.RandomPartitioner");
-    segments = generator.generateSegments(3, tokens);
-    assertEquals(11, segments.size());
-    assertEquals("(5,6)", segments.get(0).toString());
-    assertEquals("(6,18904575940052136859076367079542678419)", segments.get(1).toString());
-    assertEquals("(151236607520417094872610936636341427319,5)", segments.get(10).toString());
+    tokens = Lists.transform(
+        Lists.newArrayList(
+            "5", "6",
+            "56713727820156410577229101238628035242", "56713727820156410577229101238628035243",
+            "113427455640312821154458202477256070484", "113427455640312821154458202477256070485"),
+        new Function<String, BigInteger>() {
+          @Nullable
+          @Override
+          public BigInteger apply(@Nullable String s) {
+            return new BigInteger(s);
+          }
+        }
+    );
 
-    tokenStrings = Lists.newArrayList("-9223372036854775808", "-9223372036854775807",
-                                "-3074457345618258603", "-3074457345618258602", "3074457345618258602", "3074457345618258603");
-    tokens = Lists.transform(tokenStrings, new Function<String, BigInteger>() {
-      @Nullable
-      @Override
-      public BigInteger apply(@Nullable String s) {
-        return new BigInteger(s);
-      }
-    });
-
-    generator = new SegmentGenerator("foo.bar.Murmur3Partitioner");
-    segments = generator.generateSegments(3, tokens);
-    assertEquals(12, segments.size());
-    */
+    segments = generator.generateSegments(10, tokens);
+    assertEquals(15, segments.size());
+    assertEquals("[5,6)",
+                 segments.get(0).toString());
+    assertEquals("[56713727820156410577229101238628035242,56713727820156410577229101238628035243)",
+                 segments.get(5).toString());
+    assertEquals("[113427455640312821154458202477256070484,113427455640312821154458202477256070485)",
+                 segments.get(10).toString());
   }
 
   @Test(expected=ReaperException.class)
   public void testZeroSizeRange() throws Exception {
-    List<String> tokenStrings = Lists.newArrayList("0", "1",
-                                                   "56713727820156410577229101238628035242", "56713727820156410577229101238628035242",
-                                                   "113427455640312821154458202477256070484", "113427455640312821154458202477256070485");
+    List<String> tokenStrings = Lists.newArrayList(
+        "0", "1",
+        "56713727820156410577229101238628035242", "56713727820156410577229101238628035242",
+        "113427455640312821154458202477256070484", "113427455640312821154458202477256070485");
     List<BigInteger> tokens = Lists.transform(tokenStrings, new Function<String, BigInteger>() {
       @Nullable
       @Override
@@ -102,7 +83,52 @@ public class SegmentGeneratorTest {
     });
 
     SegmentGenerator generator = new SegmentGenerator("foo.bar.RandomPartitioner");
-    List<RepairSegment> segments = generator.generateSegments(3, tokens);
+    generator.generateSegments(10, tokens);
+  }
+
+  @Test
+  public void testRotatedRing() throws Exception {
+    List<String> tokenStrings = Lists.newArrayList(
+        "56713727820156410577229101238628035243", "113427455640312821154458202477256070484",
+        "113427455640312821154458202477256070485", "5",
+        "6", "56713727820156410577229101238628035242");
+    List<BigInteger> tokens = Lists.transform(tokenStrings, new Function<String, BigInteger>() {
+      @Nullable
+      @Override
+      public BigInteger apply(@Nullable String s) {
+        return new BigInteger(s);
+      }
+    });
+
+    SegmentGenerator generator = new SegmentGenerator("foo.bar.RandomPartitioner");
+    List<RepairSegment> segments = generator.generateSegments(10, tokens);
+    assertEquals(15, segments.size());
+    assertEquals("[113427455640312821154458202477256070484,113427455640312821154458202477256070485)",
+                 segments.get(4).toString());
+    assertEquals("[5,6)",
+                 segments.get(9).toString());
+    assertEquals("[56713727820156410577229101238628035242,56713727820156410577229101238628035243)",
+                 segments.get(14).toString());
+  }
+
+  @Test(expected=ReaperException.class)
+  public void testDisorderedRing() throws Exception {
+    List<String> tokenStrings = Lists.newArrayList(
+        "0", "113427455640312821154458202477256070485", "1",
+        "56713727820156410577229101238628035242", "56713727820156410577229101238628035243",
+        "113427455640312821154458202477256070484");
+    List<BigInteger> tokens = Lists.transform(tokenStrings, new Function<String, BigInteger>() {
+      @Nullable
+      @Override
+      public BigInteger apply(@Nullable String s) {
+        return new BigInteger(s);
+      }
+    });
+
+    SegmentGenerator generator = new SegmentGenerator("foo.bar.RandomPartitioner");
+    generator.generateSegments(10, tokens);
+    // Will throw an exception when concluding that the repair segments don't add up.
+    // This is because the tokens were supplied out of order.
   }
 
   @Test


### PR DESCRIPTION
New implementation of generateSegments that takes a total number of requested segments, rather than segments per token range. Because it rounds everything up (especially useful for handling the size 1 ranges), it often produces a few more segments. But always at least as many as asked for.
