### PR TITLE
Zvo/jmx features

### DIFF
--- a/src/main/java/com/spotify/reaper/cassandra/JmxProxy.java
+++ b/src/main/java/com/spotify/reaper/cassandra/JmxProxy.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Lists;
 import com.spotify.reaper.ReaperException;
 import com.spotify.reaper.service.RingRange;
 
+import org.apache.cassandra.db.compaction.CompactionManager;
+import org.apache.cassandra.db.compaction.CompactionManagerMBean;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.service.StorageServiceMBean;
 import org.slf4j.Logger;
@@ -54,23 +56,26 @@ public class JmxProxy implements NotificationListener, Serializable {
 
   private static final int JMX_PORT = 7199;
   private static final String JMX_URL = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
-  private static final String JMX_OBJECT_NAME = "org.apache.cassandra.db:type=StorageService";
+  private static final String SS_OBJECT_NAME = "org.apache.cassandra.db:type=StorageService";
 
   private final JMXConnector jmxConnector;
-  private final ObjectName mbeanName;
+  private final ObjectName ssMbeanName;
   private final MBeanServerConnection mbeanServer;
   private final StorageServiceMBean ssProxy;
   private final Optional<RepairStatusHandler> repairStatusHandler;
   private final String host;
+  private final CompactionManagerMBean cmProxy;
 
   private JmxProxy(Optional<RepairStatusHandler> handler, String host, JMXConnector jmxConnector,
-      StorageServiceMBean ssProxy, ObjectName mbeanName, MBeanServerConnection mbeanServer) {
+      StorageServiceMBean ssProxy, ObjectName ssMbeanName, MBeanServerConnection mbeanServer,
+      CompactionManagerMBean cmProxy) {
     this.host = host;
     this.jmxConnector = jmxConnector;
-    this.mbeanName = mbeanName;
+    this.ssMbeanName = ssMbeanName;
     this.mbeanServer = mbeanServer;
     this.ssProxy = ssProxy;
     this.repairStatusHandler = handler;
+    this.cmProxy = cmProxy;
   }
 
   /**
@@ -106,10 +111,12 @@ public class JmxProxy implements NotificationListener, Serializable {
   public static JmxProxy connect(Optional<RepairStatusHandler> handler, String host, int port)
       throws ReaperException {
     JMXServiceURL jmxUrl;
-    ObjectName mbeanName;
+    ObjectName ssMbeanName;
+    ObjectName cmMbeanName;
     try {
       jmxUrl = new JMXServiceURL(String.format(JMX_URL, host, port));
-      mbeanName = new ObjectName(JMX_OBJECT_NAME);
+      ssMbeanName = new ObjectName(SS_OBJECT_NAME);
+      cmMbeanName = new ObjectName(CompactionManager.MBEAN_OBJECT_NAME);
     } catch (MalformedURLException | MalformedObjectNameException e) {
       LOG.error("Failed to prepare the JMX connection");
       throw new ReaperException("Failure during preparations for JMX connection", e);
@@ -118,11 +125,14 @@ public class JmxProxy implements NotificationListener, Serializable {
       JMXConnector jmxConn = JMXConnectorFactory.connect(jmxUrl);
       MBeanServerConnection mbeanServerConn = jmxConn.getMBeanServerConnection();
       StorageServiceMBean ssProxy =
-          JMX.newMBeanProxy(mbeanServerConn, mbeanName, StorageServiceMBean.class);
-      JmxProxy proxy = new JmxProxy(handler, host, jmxConn, ssProxy, mbeanName, mbeanServerConn);
+          JMX.newMBeanProxy(mbeanServerConn, ssMbeanName, StorageServiceMBean.class);
+      CompactionManagerMBean cmProxy =
+          JMX.newMBeanProxy(mbeanServerConn, cmMbeanName, CompactionManagerMBean.class);
+      JmxProxy proxy =
+          new JmxProxy(handler, host, jmxConn, ssProxy, ssMbeanName, mbeanServerConn, cmProxy);
       // registering a listener throws bunch of exceptions, so we do it here rather than in the
       // constructor
-      mbeanServerConn.addNotificationListener(mbeanName, proxy, null, null);
+      mbeanServerConn.addNotificationListener(ssMbeanName, proxy, null, null);
       LOG.info(String.format("JMX connection to %s properly connected.", host));
       return proxy;
     } catch (IOException | InstanceNotFoundException e) {
@@ -193,6 +203,14 @@ public class JmxProxy implements NotificationListener, Serializable {
   }
 
   /**
+   * @return number of pending compactions on the node this proxy is connected to
+   */
+  public int getPendingCompactions() {
+    checkNotNull(cmProxy, "Looks like the proxy is not connected");
+    return cmProxy.getPendingTasks();
+  }
+
+  /**
    * Triggers a repair of range (beginToken, endToken] for given keyspace and column family.
    *
    * The repair is triggered by {@link org.apache.cassandra.service.StorageServiceMBean#forceRepairRangeAsync}
@@ -260,7 +278,7 @@ public class JmxProxy implements NotificationListener, Serializable {
    */
   public void close() throws ReaperException {
     try {
-      mbeanServer.removeNotificationListener(mbeanName, this);
+      mbeanServer.removeNotificationListener(ssMbeanName, this);
       jmxConnector.close();
     } catch (IOException | InstanceNotFoundException | ListenerNotFoundException e) {
       throw new ReaperException(e);

--- a/src/main/java/com/spotify/reaper/cassandra/JmxProxy.java
+++ b/src/main/java/com/spotify/reaper/cassandra/JmxProxy.java
@@ -211,6 +211,14 @@ public class JmxProxy implements NotificationListener, Serializable {
   }
 
   /**
+   * Terminates all ongoing repairs on the node this proxy is connected to
+   */
+  public void cancelAllRepairs() {
+    checkNotNull(ssProxy, "Looks like the proxy is not connected");
+    ssProxy.forceTerminateAllRepairSessions();
+  }
+
+  /**
    * Triggers a repair of range (beginToken, endToken] for given keyspace and column family.
    *
    * The repair is triggered by {@link org.apache.cassandra.service.StorageServiceMBean#forceRepairRangeAsync}

--- a/src/main/java/com/spotify/reaper/resources/TableResource.java
+++ b/src/main/java/com/spotify/reaper/resources/TableResource.java
@@ -249,7 +249,7 @@ public class TableResource {
 
     // check if the table actually exists in the Cassandra cluster
     if (!existsInCluster(cluster, keyspace, table)) {
-      String errMsg = String.format("table \"%s\" actually doesn't exists in Cassandra",
+      String errMsg = String.format("table \"%s\" doesn't exists in Cassandra",
           createdUri.toString());
       throw new ReaperException(errMsg);
     }
@@ -271,9 +271,14 @@ public class TableResource {
    * @return
    */
   private boolean existsInCluster(Cluster cluster, String keyspace, String table) {
-    // TODO(zvo): verify that the table also exists in the cluster.
-    LOG.warn("Skipping check for existence of {}/{} in cluster {}", keyspace, table, cluster);
-    return true;
+    String seedHost = cluster.getSeedHosts().iterator().next();
+    try {
+      return jmxFactory.create(seedHost).tableExists(keyspace, table);
+    } catch (ReaperException e) {
+      LOG.error(e.getMessage());
+      e.printStackTrace();
+      return false;
+    }
   }
 
   /**

--- a/src/test/java/com/spotify/reaper/resources/TableResourceTest.java
+++ b/src/test/java/com/spotify/reaper/resources/TableResourceTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -78,6 +79,7 @@ public class TableResourceTest {
     when(proxy.getClusterName()).thenReturn(CLUSTER_NAME);
     when(proxy.getPartitioner()).thenReturn(PARTITIONER);
     when(proxy.getTokens()).thenReturn(TOKENS);
+    when(proxy.tableExists(anyString(), anyString())).thenReturn(Boolean.TRUE);
     factory = new JmxConnectionFactory() {
       @Override
       public JmxProxy create(String host) throws ReaperException {


### PR DESCRIPTION
A set of 3 features for the JmxProxy:
- fetch pending compactions will be used in RepairRunner to decide if to trigger a repair or not
- cancelling all repairs will be used when re-starting the reaper
- check for able existence is needed when registering a new table to be repaired

