### PR TITLE
Remove the unused ERROR state from RepairSegment

### DIFF
--- a/src/main/java/com/spotify/reaper/core/RepairSegment.java
+++ b/src/main/java/com/spotify/reaper/core/RepairSegment.java
@@ -78,7 +78,6 @@ public class RepairSegment {
   public enum State {
     NOT_STARTED,
     RUNNING,
-    ERROR,
     DONE
   }
 


### PR DESCRIPTION
This breaks existing database records storing the DONE state, which now moves from index 3 to 2.

For existing records, I think it only affects RepairRunResource.getRepairRunStatus where segments_repaired will show up as 0. It would be more harmful to change this later, so better do it now.