### PR TITLE
use validation annotations instead of assertions, minor refactoring

### DIFF
--- a/src/main/java/com/spotify/reaper/ReaperApplication.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplication.java
@@ -161,14 +161,11 @@ public class ReaperApplication extends Application<ReaperApplicationConfiguratio
 
   private void checkConfiguration(ReaperApplicationConfiguration config) throws ReaperException {
     LOG.debug("repairIntensity: " + config.getRepairIntensity());
-    assert config.getRepairIntensity() > 0.0 && config.getRepairIntensity() <= 1.0 :
-        "repairIntensity must be a value between 0.0 and 1.0, but not 0.";
     LOG.debug("repairRunThreadCount: " + config.getRepairRunThreadCount());
     LOG.debug("segmentCount: " + config.getSegmentCount());
     LOG.debug("repairParallelism: " + config.getRepairParallelism());
     LOG.debug("hangingRepairTimeoutMins: " + config.getHangingRepairTimeoutMins());
     LOG.debug("jmxPorts: " + config.getJmxPorts());
-    checkRepairParallelismString(config.getRepairParallelism());
   }
 
   public static void checkRepairParallelismString(String givenRepairParallelism)

--- a/src/main/java/com/spotify/reaper/ReaperApplication.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplication.java
@@ -47,19 +47,19 @@ public class ReaperApplication extends Application<ReaperApplicationConfiguratio
 
   static final Logger LOG = LoggerFactory.getLogger(ReaperApplication.class);
 
-  private static AppContext context;
+  private  AppContext context;
 
   public ReaperApplication() {
     super();
     LOG.info("default ReaperApplication constructor called");
-    ReaperApplication.context = new AppContext();
+    this.context = new AppContext();
   }
 
   @VisibleForTesting
   public ReaperApplication(AppContext context) {
     super();
     LOG.info("ReaperApplication constructor called with custom AppContext");
-    ReaperApplication.context = context;
+    this.context = context;
   }
 
   public static void main(String[] args) throws Exception {

--- a/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
@@ -21,8 +21,8 @@ import org.hibernate.validator.constraints.NotEmpty;
 import java.util.Map;
 
 import javax.validation.Valid;
+import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import io.dropwizard.Configuration;
@@ -40,7 +40,7 @@ public class ReaperApplicationConfiguration extends Configuration {
 
   @JsonProperty
   @NotNull
-  @Min(0)
+  @DecimalMin(value = "0", inclusive=false)
   @Max(1)
   private Double repairIntensity;
 
@@ -106,6 +106,10 @@ public class ReaperApplicationConfiguration extends Configuration {
 
   public DataSourceFactory getDataSourceFactory() {
     return database;
+  }
+
+  public void setDataSourceFactory(DataSourceFactory database) {
+    this.database = database;
   }
 
   public int getHangingRepairTimeoutMins() {

--- a/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
@@ -15,11 +15,14 @@ package com.spotify.reaper;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.apache.cassandra.repair.RepairParallelism;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import java.util.Map;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import io.dropwizard.Configuration;
@@ -33,10 +36,12 @@ public class ReaperApplicationConfiguration extends Configuration {
 
   @JsonProperty
   @NotNull
-  private String repairParallelism;
+  private RepairParallelism repairParallelism;
 
   @JsonProperty
   @NotNull
+  @Min(0)
+  @Max(1)
   private Double repairIntensity;
 
   @JsonProperty
@@ -67,11 +72,11 @@ public class ReaperApplicationConfiguration extends Configuration {
     this.segmentCount = segmentCount;
   }
 
-  public String getRepairParallelism() {
+  public RepairParallelism getRepairParallelism() {
     return repairParallelism;
   }
 
-  public void setRepairParallelism(String repairParallelism) {
+  public void setRepairParallelism(RepairParallelism repairParallelism) {
     this.repairParallelism = repairParallelism;
   }
 

--- a/src/main/java/com/spotify/reaper/resources/CommonTools.java
+++ b/src/main/java/com/spotify/reaper/resources/CommonTools.java
@@ -20,7 +20,7 @@ import com.spotify.reaper.service.SegmentGenerator;
 
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,8 +32,6 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class CommonTools {
-
-  public static final String TIMESTAMP_ISO8601_YODA_TEMPLATE = "YYYY-MM-dd'T'HH:mm:ss'Z'";
 
   private static final Logger LOG = LoggerFactory.getLogger(CommonTools.class);
 
@@ -245,7 +243,7 @@ public class CommonTools {
   }
 
   public static String dateTimeToISO8601(DateTime dateTime) {
-    return dateTime.toDateTime(DateTimeZone.UTC).toString(TIMESTAMP_ISO8601_YODA_TEMPLATE);
+    return ISODateTimeFormat.dateTimeNoMillis().print(dateTime);
   }
 
   public static double roundDoubleNicely(double intensity) {

--- a/src/main/java/com/spotify/reaper/resources/RepairRunResource.java
+++ b/src/main/java/com/spotify/reaper/resources/RepairRunResource.java
@@ -14,12 +14,10 @@
 package com.spotify.reaper.resources;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Optional;
-
-import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
 import com.spotify.reaper.AppContext;
 import com.spotify.reaper.ReaperApplication;
 import com.spotify.reaper.ReaperException;
@@ -132,16 +130,16 @@ public class RepairRunResource {
       RepairUnit theRepairUnit =
           CommonTools.getNewOrExistingRepairUnit(context, cluster, keyspace.get(), tableNames);
 
-      String repairParallelismStr = context.config.getRepairParallelism();
+      RepairParallelism parallelism = context.config.getRepairParallelism();
       if (repairParallelism.isPresent()) {
         LOG.debug("using given repair parallelism {} instead of configured value {}",
                   repairParallelism.get(), context.config.getRepairParallelism());
-        repairParallelismStr = repairParallelism.get();
+        parallelism = RepairParallelism.valueOf(repairParallelism.get().toUpperCase());
       }
 
       RepairRun newRepairRun = CommonTools.registerRepairRun(
           context, cluster, theRepairUnit, cause, owner.get(), segments,
-          RepairParallelism.valueOf(repairParallelismStr.toUpperCase()), intensity);
+          parallelism, intensity);
 
       return Response.created(buildRepairRunURI(uriInfo, newRepairRun))
           .entity(new RepairRunStatus(newRepairRun, theRepairUnit)).build();

--- a/src/main/java/com/spotify/reaper/resources/RepairScheduleResource.java
+++ b/src/main/java/com/spotify/reaper/resources/RepairScheduleResource.java
@@ -148,16 +148,16 @@ public class RepairScheduleResource {
       RepairUnit theRepairUnit =
           CommonTools.getNewOrExistingRepairUnit(context, cluster, keyspace.get(), tableNames);
 
-      String repairParallelismStr = context.config.getRepairParallelism();
+      RepairParallelism parallelism = context.config.getRepairParallelism();
       if (repairParallelism.isPresent()) {
         LOG.debug("using given repair parallelism {} instead of configured value {}",
                   repairParallelism.get(), context.config.getRepairParallelism());
-        repairParallelismStr = repairParallelism.get();
+        parallelism = RepairParallelism.valueOf(repairParallelism.get().toUpperCase());
       }
 
       RepairSchedule newRepairSchedule = CommonTools.storeNewRepairSchedule(
           context, cluster, theRepairUnit, scheduleDaysBetween.get(), nextActivation, owner.get(),
-          segments, RepairParallelism.valueOf(repairParallelismStr.toUpperCase()), intensity);
+          segments, parallelism, intensity);
 
       return Response.created(buildRepairScheduleURI(uriInfo, newRepairSchedule))
           .entity(new RepairScheduleStatus(newRepairSchedule, theRepairUnit)).build();

--- a/src/test/java/com/spotify/reaper/ReaperApplicationConfigurationTest.java
+++ b/src/test/java/com/spotify/reaper/ReaperApplicationConfigurationTest.java
@@ -1,0 +1,51 @@
+package com.spotify.reaper;
+
+import org.apache.cassandra.repair.RepairParallelism;
+import org.hibernate.validator.HibernateValidator;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import io.dropwizard.db.DataSourceFactory;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class ReaperApplicationConfigurationTest {
+
+  private final Validator validator = Validation
+      .byProvider(HibernateValidator.class)
+      .configure()
+      .buildValidatorFactory()
+      .getValidator();
+
+  private final ReaperApplicationConfiguration config = new ReaperApplicationConfiguration();
+
+  @Before
+  public void setUp() {
+    //create a valid config
+    DataSourceFactory dataSourceFactory = new DataSourceFactory();
+    dataSourceFactory.setDriverClass("org.postgresql.Driver");
+    dataSourceFactory.setUrl("jdbc:postgresql://db.example.com/db-prod");
+    dataSourceFactory.setUser("user");
+    config.setDataSourceFactory(dataSourceFactory);
+    config.setHangingRepairTimeoutMins(1);
+    config.setRepairParallelism(RepairParallelism.DATACENTER_AWARE);
+    config.setRepairRunThreadCount(1);
+    config.setSegmentCount(1);
+    config.setStorageType("foo");
+  }
+
+  @Test
+  public void testRepairIntensity() {
+    config.setRepairIntensity(-0.1);
+    assertThat(validator.validate(config)).hasSize(1);
+
+    config.setRepairIntensity(0);
+    assertThat(validator.validate(config)).hasSize(1);
+
+    config.setRepairIntensity(1);
+    assertThat(validator.validate(config)).hasSize(0);
+  }
+}

--- a/src/test/java/com/spotify/reaper/resources/CommonToolsTest.java
+++ b/src/test/java/com/spotify/reaper/resources/CommonToolsTest.java
@@ -1,0 +1,16 @@
+package com.spotify.reaper.resources;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CommonToolsTest {
+
+  @Test
+  public void testDateTimeToISO8601() {
+    DateTime dateTime = new DateTime(2015, 2, 20, 15, 24, 45, DateTimeZone.UTC);
+    assertEquals("2015-02-20T15:24:45Z", CommonTools.dateTimeToISO8601(dateTime));
+  }
+}


### PR DESCRIPTION
While checking out cassandra-reaper I noticed two places where the `assert` keyword is used to validate the configuration file. These checks can actually be moved into the configuration class itself to have dropwizard validate the property at startup - for instance if the config file has a repairIntensity > 1.0:

```
cassandra-reaper.yaml has an error:
  * repairIntensity must be less than or equal to 1 (was 10.9)
```

Jackson can also map enum fields, so there is no need to convert from a String to the `RepairParallelism` enum. For example if I have `repairParallelism: foo` in the YAML:

```
cassandra-reaper.yaml has an error:
  * Failed to parse configuration at: repairParallelism; foo was not one of [SEQUENTIAL, PARALLEL, DATACENTER_AWARE]
 at [Source: N/A; line: -1, column: -1] (through reference chain: com.spotify.reaper.ReaperApplicationConfiguration["repairParallelism"])
```

Since assertions generally aren't enabled at runtime, this means these config checks can always be applied and not just when the assertions are explicitly enabled.

(For the same reason, it might be better to use something like `Preconditions.checkNotNull(...)` from guava for other places where `assert null != foo` is used)

While making this change I noticed that there isn't really a need for the AppContext field to be static in the ReaperApplication class, and a place where a JodaTime-builtin formatter can be used.