### PR TITLE
Support for H2 embedded Java database

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ Reaper system does not use internal caches for state changes regarding running r
 registered clusters, which means that any changes done to the storage will reflect to the running
 system dynamically.
 
-You can also run the Reaper with memory storage, which is not persistent, which means that all
-the registered clusters, column families, and repair runs will be lost upon service restart.
-The memory based storage is meant to be used for testing purposes only.
-
 This project is built on top of Dropwizard:
 http://dropwizard.io/
 
@@ -40,33 +36,46 @@ Usage
 
 To run Cassandra Reaper you need to simply build a project package using Maven, and
 then execute the created Java jar file, and give a path to the system configuration file
-as the first and only argument. You can also use the provided *bin/cassandra-reaper* script
+as the first and only argument. You can also use the provided `bin/cassandra-reaper` script
 to run the service.
 
-When using database based storage, you must setup a PostgreSQL database yourself and configure
-Reaper to use it. You need to prepare the database using the given schema in:
-*src/main/db/reaper_db.sql*
-
-For configuring the service, see the available configuration options in later section
-of this readme document.
-
-You can call the service directly through the REST API using a tool like *curl*. You can also
-use the provided CLI tool in *bin/spreaper* to call the service.
+You can call the service directly through the REST API using a tool like `curl`. You can also
+use the provided CLI tool in `bin/spreaper` to call the service.
 Run the tool with *-h* or *--help* option to see usage instructions.
 
 Notice that you can also build a Debian package from this project by using *debuild*, for example:
-*debuild -uc -us -b*
+`debuild -uc -us -b`
 
 
 Configuration
 -------------
 
 An example testing configuration YAML file can be found from within this project repository:
-*src/test/resources/cassandra-reaper.yaml*
+`src/test/resources/cassandra-reaper.yaml`
 
 The configuration file structure is provided by Dropwizard, and help on configuring the server,
-database connection, or logging, can be found from:
-*http://dropwizard.io/manual/configuration.html*
+database connection, or logging, can be found at:
+http://dropwizard.io/manual/configuration.html
+
+
+**Storage Backend**
+
+Cassandra Reaper can be used with either an ephemeral memory storage or persistent database. Running Reaper with memory storage, which is not persistent, means that all
+the registered clusters, column families, and repair runs will be lost upon service restart.
+The memory based storage is meant to be used for testing purposes only. Enable this type of storage by using the `storageType: memory` setting in your config file (enabled by default).
+
+For persistent database storage, you must either setup PostgreSQL or H2. You also need to set `storageType: database` in the config file.
+* PostgreSQL - you'll first have to prepare the database manually using the provided schema in: `src/main/db/reaper_db.sql`.
+Afterwards make sure to specify the correct credentials in your JDBC settings in `cassandra-reaper.yaml`.
+* H2 - the database will automatically created for you under the path configured in `cassandra-reaper.yaml`. Please
+comment/uncomment the H2 settings and modify the path as needed.
+
+For configuring other aspects of the service, see the available configuration options in later section
+of this readme document.
+
+
+
+**Reaper Settings**
 
 The Reaper service specific configuration values are:
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
             <artifactId>postgresql</artifactId>
             <version>9.3-1100-jdbc41</version>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.186</version>
+        </dependency>
+                
+                
 
         <!--test scope-->
         <dependency>

--- a/src/main/java/com/spotify/reaper/storage/PostgresStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/PostgresStorage.java
@@ -16,8 +16,6 @@ package com.spotify.reaper.storage;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
-import com.spotify.reaper.ReaperApplicationConfiguration;
-import com.spotify.reaper.ReaperException;
 import com.spotify.reaper.core.Cluster;
 import com.spotify.reaper.core.RepairRun;
 import com.spotify.reaper.core.RepairSchedule;
@@ -44,8 +42,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import io.dropwizard.jdbi.DBIFactory;
-import io.dropwizard.setup.Environment;
 
 /**
  * Implements the StorageAPI using PostgreSQL database.
@@ -56,15 +52,8 @@ public class PostgresStorage implements IStorage {
 
   private final DBI jdbi;
 
-  public PostgresStorage(ReaperApplicationConfiguration config, Environment environment)
-      throws ReaperException {
-    try {
-      final DBIFactory factory = new DBIFactory();
-      jdbi = factory.build(environment, config.getDataSourceFactory(), "postgresql");
-    } catch (ClassNotFoundException ex) {
-      LOG.error("failed creating database connection: {}", ex);
-      throw new ReaperException(ex);
-    }
+  public PostgresStorage(DBI jdbi) {
+    this.jdbi = jdbi;
   }
 
   private static IStoragePostgreSQL getPostgresStorage(Handle h) {

--- a/src/main/java/com/spotify/reaper/storage/postgresql/ClusterMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/ClusterMapper.java
@@ -13,20 +13,27 @@
  */
 package com.spotify.reaper.storage.postgresql;
 
-import com.google.common.collect.Sets;
-
-import com.spotify.reaper.core.Cluster;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
 
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import com.google.common.collect.Sets;
+import com.spotify.reaper.core.Cluster;
 
 public class ClusterMapper implements ResultSetMapper<Cluster> {
 
   public Cluster map(int index, ResultSet r, StatementContext ctx) throws SQLException {
-    String[] seedHosts = (String[]) r.getArray("seed_hosts").getArray();
+    String[] seedHosts = null;
+    Object obj = r.getArray("seed_hosts").getArray();
+    if(obj instanceof String[]) {
+      seedHosts = (String[])obj;
+    } else if(obj instanceof Object[]) {
+      Object[] ol = (Object[])obj;
+      seedHosts = Arrays.copyOf(ol, ol.length, String[].class);
+    }
     return new Cluster(r.getString("name"), r.getString("partitioner"), Sets.newHashSet(seedHosts));
   }
 

--- a/src/main/java/com/spotify/reaper/storage/postgresql/IStoragePostgreSQL.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/IStoragePostgreSQL.java
@@ -94,7 +94,9 @@ public interface IStoragePostgreSQL {
   static final String SQL_GET_REPAIR_UNIT_BY_CLUSTER_AND_TABLES =
       "SELECT " + SQL_REPAIR_UNIT_ALL_FIELDS + " FROM repair_unit "
       + "WHERE cluster_name = :clusterName AND keyspace_name = :keyspaceName "
-      + "AND column_families @> :columnFamilies AND column_families <@ :columnFamilies";
+      + "AND column_families = :columnFamilies";
+  
+  
   static final String SQL_DELETE_REPAIR_UNIT = "DELETE FROM repair_unit WHERE id = :id";
 
   // RepairSegment

--- a/src/main/java/com/spotify/reaper/storage/postgresql/LongCollectionSQLTypeArgumentFactory.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/LongCollectionSQLTypeArgumentFactory.java
@@ -28,8 +28,14 @@ public class LongCollectionSQLTypeArgumentFactory
     return new Argument() {
       public void apply(int position, PreparedStatement statement, StatementContext ctx)
           throws SQLException {
-        Array sqlArray = ctx.getConnection().createArrayOf("int", value.getValue().toArray());
-        statement.setArray(position, sqlArray);
+        try {
+          Array sqlArray = ctx.getConnection().createArrayOf("int", value.getValue().toArray());
+          statement.setArray(position, sqlArray);
+        } catch(SQLException e) {
+          // H2 DB feature not supported: "createArray" error
+          if(e.getErrorCode() != 50100) throw e;
+          statement.setObject(position, value.getValue().toArray());
+        }
       }
     };
   }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/PostgresArrayArgumentFactory.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/PostgresArrayArgumentFactory.java
@@ -43,8 +43,14 @@ public class PostgresArrayArgumentFactory implements ArgumentFactory<Collection<
     return new Argument() {
       public void apply(int position, PreparedStatement statement, StatementContext ctx)
           throws SQLException {
-        Array sqlArray = ctx.getConnection().createArrayOf("text", value.toArray());
-        statement.setArray(position, sqlArray);
+        try {
+          Array sqlArray = ctx.getConnection().createArrayOf("text", value.toArray());
+          statement.setArray(position, sqlArray);
+        } catch(SQLException e) {
+          // H2 DB feature not supported: "createArray" error
+          if(e.getErrorCode() != 50100) throw e;
+          statement.setObject(position, value.toArray());
+        }
       }
     };
   }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairUnitMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairUnitMapper.java
@@ -14,7 +14,6 @@
 package com.spotify.reaper.storage.postgresql;
 
 import com.google.common.collect.Sets;
-
 import com.spotify.reaper.core.RepairUnit;
 
 import org.skife.jdbi.v2.StatementContext;
@@ -22,11 +21,20 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
 
 public class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
 
   public RepairUnit map(int index, ResultSet r, StatementContext ctx) throws SQLException {
-    String[] columnFamilies = (String[]) r.getArray("column_families").getArray();
+    String[] columnFamilies = null;
+    Object obj = r.getArray("column_families").getArray();
+    if(obj instanceof String[]) {
+      columnFamilies = (String[]) obj;
+    } else if(obj instanceof Object[]) {
+      Object[] ocf = (Object[]) obj;
+      columnFamilies = Arrays.copyOf(ocf, ocf.length, String[].class);
+    }
+    
     RepairUnit.Builder builder = new RepairUnit.Builder(r.getString("cluster_name"),
                                                         r.getString("keyspace_name"),
                                                         Sets.newHashSet(columnFamilies));

--- a/src/main/resources/db/reaper_h2.sql
+++ b/src/main/resources/db/reaper_h2.sql
@@ -1,0 +1,83 @@
+--
+-- H2 schema for cassandra-reaper database
+--
+
+-- For cleaning up the database, just do first in the following order:
+-- DROP TABLE repair_segment;
+-- DROP TABLE repair_run;
+-- DROP TABLE repair_schedule;
+-- DROP TABLE repair_unit;
+-- DROP TABLE cluster;
+
+CREATE TABLE IF NOT EXISTS cluster (
+  name        VARCHAR PRIMARY KEY,
+  partitioner VARCHAR    NOT NULL,
+  seed_hosts  ARRAY NOT NULL
+);
+
+-- Repair unit is basically a keyspace with a set of column families.
+-- Cassandra supports repairing multiple column families in one go.
+--
+CREATE TABLE IF NOT EXISTS repair_unit (
+  id              SERIAL PRIMARY KEY,
+  cluster_name    VARCHAR    NOT NULL REFERENCES cluster (name),
+  keyspace_name   VARCHAR    NOT NULL,
+  column_families ARRAY NOT NULL
+);
+
+CREATE INDEX repair_unit_column_families_gin_idx ON repair_unit (column_families);
+
+
+CREATE TABLE IF NOT EXISTS repair_run (
+  id                 SERIAL PRIMARY KEY,
+  cluster_name       VARCHAR                     NOT NULL REFERENCES cluster (name),
+  repair_unit_id     INT                      NOT NULL REFERENCES repair_unit (id),
+  cause              VARCHAR                     NOT NULL,
+  owner              VARCHAR                     NOT NULL,
+-- see (Java) RepairRun.RunState for state values
+  state              VARCHAR                     NOT NULL,
+  creation_time      TIMESTAMP NOT NULL,
+  start_time         TIMESTAMP DEFAULT NULL,
+  end_time           TIMESTAMP DEFAULT NULL,
+  pause_time         TIMESTAMP DEFAULT NULL,
+  intensity          REAL                     NOT NULL,
+  last_event         VARCHAR                     NOT NULL,
+  segment_count      INT                      NOT NULL,
+  repair_parallelism VARCHAR                     NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS repair_segment (
+  id               SERIAL PRIMARY KEY,
+  repair_unit_id   INT         NOT NULL REFERENCES repair_unit (id),
+  run_id           INT         NOT NULL REFERENCES repair_run (id),
+  start_token      NUMERIC(50) NOT NULL,
+  end_token        NUMERIC(50) NOT NULL,
+-- see (Java) RepairSegment.State for state values
+  state            SMALLINT    NOT NULL,
+  coordinator_host VARCHAR                     DEFAULT NULL,
+  start_time       TIMESTAMP DEFAULT NULL,
+  end_time         TIMESTAMP DEFAULT NULL,
+  fail_count       INT         NOT NULL     DEFAULT 0
+);
+
+CREATE INDEX repair_segment_run_id_fail_count_idx ON repair_segment (run_id ASC, fail_count ASC);
+
+CREATE INDEX repair_segment_state_idx ON repair_segment (state);
+
+CREATE TABLE IF NOT EXISTS repair_schedule (
+  id                 SERIAL PRIMARY KEY,
+  repair_unit_id     INT                      NOT NULL REFERENCES repair_unit (id),
+-- see (Java) RepairSchedule.State for state values
+  state              VARCHAR                     NOT NULL,
+  days_between       SMALLINT                 NOT NULL,
+  next_activation    TIMESTAMP NOT NULL,
+-- run_history contains repair run ids, with latest scheduled run in the end
+  run_history        ARRAY                   NOT NULL,
+  segment_count      INT                      NOT NULL,
+  repair_parallelism VARCHAR                     NOT NULL,
+  intensity          REAL                     NOT NULL,
+  creation_time      TIMESTAMP NOT NULL,
+  owner              VARCHAR                     NOT NULL,
+  pause_time         TIMESTAMP DEFAULT NULL
+);
+

--- a/src/test/resources/cassandra-reaper.yaml
+++ b/src/test/resources/cassandra-reaper.yaml
@@ -48,17 +48,18 @@ server:
 # database section will be ignored if storageType is set to "memory"
 #
 database:
-  # the name of your JDBC driver
+  
+  # PostgreSQL JDBC settings
   driverClass: org.postgresql.Driver
-
-  # the username
   user: pg-user
-
-  # the password
   password: iAMs00perSecrEET
-
-  # the JDBC URL
   url: jdbc:postgresql://db.example.com/db-prod
+  
+  # H2 JDBC settings
+  #driverClass: org.h2.Driver
+  #url: jdbc:h2:~/reaper-db/db;MODE=PostgreSQL
+  #user:
+  #password:
 
   # any properties specific to your JDBC driver:
   properties:


### PR DESCRIPTION
This PR will add support for H2 as another database option. As H2 supports a Postgres combat mode, only minor changes were needed when it comes to SQL and JDBC handling. 

Using H2, reaper can be distributed as a self contained package (except for yaml config) without having to rely on the in-memory store. Database files will be created automatically using the schema in the new reaper_h2.sql file.