### PR TITLE
Fix errors in cluster resource

### DIFF
--- a/src/main/java/com/spotify/reaper/core/RepairRun.java
+++ b/src/main/java/com/spotify/reaper/core/RepairRun.java
@@ -15,8 +15,9 @@ package com.spotify.reaper.core;
 
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeComparator;
 
-public class RepairRun {
+public class RepairRun implements Comparable<RepairRun> {
 
   private final long id;
 
@@ -113,6 +114,24 @@ public class RepairRun {
 
   public Builder with() {
     return new Builder(this);
+  }
+
+  /**
+   * Order RepairRun instances by time. Primarily endTime, secondarily startTime. Descending, i.e.
+   * latest first.
+   * @param other the RepairRun compared to
+   * @return negative if this RepairRun is later than the specified RepairRun. Positive if earlier.
+   *         0 if equal.
+   */
+  @Override
+  public int compareTo(RepairRun other) {
+    DateTimeComparator comparator = DateTimeComparator.getInstance();
+    int endTimeComparison = comparator.compare(endTime, other.endTime);
+    if (endTimeComparison != 0) {
+      return -endTimeComparison;
+    } else {
+      return -comparator.compare(startTime, other.startTime);
+    }
   }
 
   public enum RunState {

--- a/src/main/java/com/spotify/reaper/resources/ClusterResource.java
+++ b/src/main/java/com/spotify/reaper/resources/ClusterResource.java
@@ -79,7 +79,7 @@ public class ClusterResource {
   private Response viewCluster(String clusterName, Optional<Integer> limit,
       Optional<URI> createdURI) {
     ClusterStatus view =
-        new ClusterStatus(clusterName, context.storage.getClusterRunStatuses(clusterName, limit.or(10)));
+        new ClusterStatus(clusterName, context.storage.getClusterRunStatuses(clusterName, limit.or(Integer.MAX_VALUE)));
 
     if (view.repairRuns == null) {
       return Response.status(Response.Status.NOT_FOUND)

--- a/src/main/java/com/spotify/reaper/resources/ClusterResource.java
+++ b/src/main/java/com/spotify/reaper/resources/ClusterResource.java
@@ -80,8 +80,9 @@ public class ClusterResource {
       Optional<URI> createdURI) {
     ClusterStatus view =
         new ClusterStatus(clusterName, context.storage.getClusterRunStatuses(clusterName, limit.or(Integer.MAX_VALUE)));
+    Optional<Cluster> cluster = context.storage.getCluster(clusterName);
 
-    if (view.repairRuns == null) {
+    if (!cluster.isPresent()) {
       return Response.status(Response.Status.NOT_FOUND)
           .entity("cluster with name \"" + clusterName + "\" not found").build();
     } else if (createdURI.isPresent()) {

--- a/src/main/java/com/spotify/reaper/resources/view/ClusterStatus.java
+++ b/src/main/java/com/spotify/reaper/resources/view/ClusterStatus.java
@@ -14,6 +14,7 @@
 package com.spotify.reaper.resources.view;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spotify.reaper.core.Cluster;
 
 import java.util.Collection;
 
@@ -24,8 +25,8 @@ public class ClusterStatus {
   @JsonProperty("repair_runs")
   public final Collection<RepairRunStatus> repairRuns;
 
-  public ClusterStatus(String name, Collection<RepairRunStatus> repairRuns) {
-    this.name = name;
+  public ClusterStatus(Cluster cluster, Collection<RepairRunStatus> repairRuns) {
+    this.name = cluster.getName();
     this.repairRuns = repairRuns;
   }
 }

--- a/src/main/java/com/spotify/reaper/resources/view/ClusterStatus.java
+++ b/src/main/java/com/spotify/reaper/resources/view/ClusterStatus.java
@@ -17,16 +17,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.reaper.core.Cluster;
 
 import java.util.Collection;
+import java.util.Set;
 
 public class ClusterStatus {
 
   @JsonProperty
   public final String name;
+  @JsonProperty("seed_hosts")
+  public final Set<String> seedHosts;
   @JsonProperty("repair_runs")
   public final Collection<RepairRunStatus> repairRuns;
 
   public ClusterStatus(Cluster cluster, Collection<RepairRunStatus> repairRuns) {
     this.name = cluster.getName();
+    this.seedHosts = cluster.getSeedHosts();
     this.repairRuns = repairRuns;
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/IStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/IStorage.java
@@ -26,6 +26,8 @@ import com.spotify.reaper.service.RingRange;
 import java.util.Collection;
 import java.util.Set;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * API definition for cassandra-reaper.
  */
@@ -125,5 +127,6 @@ public interface IStorage {
    */
   Optional<RepairSchedule> deleteRepairSchedule(long id);
 
-Collection<RepairRunStatus> getClusterRunStatuses(String clusterName, int limit);
+  @NotNull
+  Collection<RepairRunStatus> getClusterRunStatuses(String clusterName, int limit);
 }

--- a/src/main/java/com/spotify/reaper/storage/MemoryStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/MemoryStorage.java
@@ -27,6 +27,7 @@ import com.spotify.reaper.service.RingRange;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -380,7 +381,7 @@ public class MemoryStorage implements IStorage {
   public Collection<RepairRunStatus> getClusterRunStatuses(String clusterName, int limit) {
     Optional<Cluster> cluster = getCluster(clusterName);
     if (!cluster.isPresent()) {
-      return null;
+      return Collections.emptyList();
     } else {
       List<RepairRunStatus> runStatuses = Lists.newArrayList();
       for (RepairRun run : getRepairRunsForCluster(clusterName)) {

--- a/src/main/java/com/spotify/reaper/storage/MemoryStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/MemoryStorage.java
@@ -14,6 +14,7 @@
 package com.spotify.reaper.storage;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -384,7 +385,9 @@ public class MemoryStorage implements IStorage {
       return Collections.emptyList();
     } else {
       List<RepairRunStatus> runStatuses = Lists.newArrayList();
-      for (RepairRun run : getRepairRunsForCluster(clusterName)) {
+      List<RepairRun> runs = getRepairRunsForCluster(clusterName);
+      Collections.sort(runs);
+      for (RepairRun run : Iterables.limit(runs, limit)) {
         RepairUnit unit = getRepairUnit(run.getRepairUnitId()).get();
         int segmentsRepaired =
             getSegmentAmountForRepairRunWithState(run.getId(), RepairSegment.State.DONE);

--- a/src/main/java/com/spotify/reaper/storage/postgresql/IStoragePostgreSQL.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/IStoragePostgreSQL.java
@@ -179,6 +179,7 @@ public interface IStoragePostgreSQL {
           + "FROM repair_run "
           + "JOIN repair_unit ON repair_unit_id = repair_unit.id "
           + "WHERE repair_unit.cluster_name = :clusterName "
+          + "ORDER BY end_time DESC, start_time DESC "
           + "LIMIT :limit";
 
   @SqlQuery("SELECT version()")

--- a/src/main/java/com/spotify/reaper/storage/postgresql/IStoragePostgreSQL.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/IStoragePostgreSQL.java
@@ -169,19 +169,16 @@ public interface IStoragePostgreSQL {
 
   // View-specific queries
   //
-
-  // TODO: segment_count may not be exactly the actual amount of segments
-  // It would be possible to query specifically for it.
   static final String SQL_CLUSTER_RUN_OVERVIEW =
       "SELECT repair_run.id, repair_unit.cluster_name, keyspace_name, column_families, "
-          + "COUNT(repair_segment.id), segment_count, repair_run.state, repair_run.start_time, "
+          + "(SELECT COUNT(case when state = 2 then 1 else null end) FROM repair_segment WHERE run_id = repair_run.id) AS segments_repaired, "
+          + "(SELECT COUNT(*) FROM repair_segment WHERE run_id = repair_run.id) AS segments_total, "
+          + "repair_run.state, repair_run.start_time, "
           + "repair_run.end_time, cause, owner, last_event, "
           + "creation_time, pause_time, intensity, repair_parallelism "
           + "FROM repair_run "
-          + "JOIN repair_segment ON run_id = repair_run.id "
-          + "JOIN repair_unit ON repair_run.repair_unit_id = repair_unit.id "
-          + "WHERE repair_unit.cluster_name = :clusterName AND repair_segment.state = 2 "
-          + "GROUP BY repair_run.id, repair_unit.id "
+          + "JOIN repair_unit ON repair_unit_id = repair_unit.id "
+          + "WHERE repair_unit.cluster_name = :clusterName "
           + "LIMIT :limit";
 
   @SqlQuery("SELECT version()")

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunStatusMapper.java
@@ -23,8 +23,8 @@ public class RepairRunStatusMapper implements ResultSetMapper<RepairRunStatus> {
     String keyspaceName = r.getString("keyspace_name");
     Collection<String> columnFamilies =
         ImmutableSet.copyOf((String[]) r.getArray("column_families").getArray());
-    int segmentsRepaired = (int)r.getLong("count");
-    int totalSegments = r.getInt("segment_count");
+    int segmentsRepaired = r.getInt("segments_repaired");
+    int totalSegments = r.getInt("segments_total");
     RepairRun.RunState state = RepairRun.RunState.valueOf(r.getString("state"));
     DateTime startTime = RepairRunMapper.getDateTimeOrNull(r, "start_time");
     DateTime endTime = RepairRunMapper.getDateTimeOrNull(r, "end_time");
@@ -36,6 +36,7 @@ public class RepairRunStatusMapper implements ResultSetMapper<RepairRunStatus> {
     Double intensity = r.getDouble("intensity");
     RepairParallelism repairParallelism =
         RepairParallelism.valueOf(r.getString("repair_parallelism"));
+
     return new RepairRunStatus(runId, clusterName, keyspaceName, columnFamilies, segmentsRepaired,
         totalSegments, state, startTime, endTime, cause, owner, lastEvent,
         creationTime, pauseTime, intensity, repairParallelism);

--- a/src/test/java/com/spotify/reaper/unit/resources/ClusterResourceTest.java
+++ b/src/test/java/com/spotify/reaper/unit/resources/ClusterResourceTest.java
@@ -87,4 +87,22 @@ public class ClusterResourceTest {
     assertTrue(msg.contains("already exists"));
     assertEquals(1, context.storage.getClusters().size());
   }
+
+  @Test
+  public void testGetNonExistingCluster() {
+    ClusterResource clusterResource = new ClusterResource(context);
+    Response response = clusterResource.getCluster("i_dont_exist", Optional.<Integer>absent());
+    assertEquals(404, response.getStatus());
+  }
+
+  @Test
+  public void testGetExistingCluster() {
+    final String I_DO_EXIST = "i_do_exist";
+    Cluster cluster = new Cluster(I_DO_EXIST, PARTITIONER, Sets.newHashSet(SEED_HOST));
+    context.storage.addCluster(cluster);
+
+    ClusterResource clusterResource = new ClusterResource(context);
+    Response response = clusterResource.getCluster(I_DO_EXIST, Optional.<Integer>absent());
+    assertEquals(200, response.getStatus());
+  }
 }


### PR DESCRIPTION
* GET would respond with empty list on non-existing clusters. Now it returns NOT_FOUND as it should.
* Now total_segments in RepairRunStatus is correct.
* Default limit on number of repair runs to show for a cluster is changed from 10 to MAX_INT
* Order repairs for a cluster by end_time and then start_time, descending. Runs with no end_time list before anything else.