### PR TITLE
Web UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-assets</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
             <version>${cassandra.version}</version>


### PR DESCRIPTION
I took the liberty to implement a web interface to interacting with the REST API. It can be found at
https://github.com/spodkowinski/cassandra-reaper-ui

The PR will enable to copy the web parts to src/main/resources and make it part of the build so it can be served directly from the reaper server. See UI installation instructions for details.

The cross-origin settings are required to call the rest api from a different development server. For me its fine to just use a system property flag for that, so I didn't want to go the whole way to add it to the config. But it should be togglable one way or another for security reasons. 