### PR TITLE
Abort repair runs

### DIFF
--- a/bin/spreaper
+++ b/bin/spreaper
@@ -210,6 +210,11 @@ def _arguments_for_pause_repair(parser):
     parser.add_argument("run_id", help="ID of the repair run to pause")
 
 
+def _arguments_for_abort_repair(parser):
+    """Arguments needed for aborting a repair"""
+    parser.add_argument("run_id", help="ID of the repair run to abort")
+
+
 def _arguments_for_start_schedule(parser):
     """Arguments relevant for resuming a repair schedule"""
     parser.add_argument("schedule_id", help="ID of the repair schedule to resume")
@@ -268,6 +273,7 @@ Usage: spreaper [<global_args>] <command> [<command_args>]
                     Reaper (add-cluster) before calling this.
     resume-repair   Resume paused repair run (or start a not started one).
     pause-repair    Pause a repair run.
+    abort-repair    Abort a repair run.
     start-schedule  Resume a paused repair schedule.
     pause-schedule  Pause a repair schedule.
     ping            Test connectivity to the Reaper service.
@@ -510,6 +516,16 @@ class ReaperCLI(object):
         print "# Pausing a repair run with id: {0}".format(args.run_id)
         reaper.put("repair_run/{0}".format(args.run_id), state="PAUSED")
         print "# Repair run '{0}' paused".format(args.run_id)
+
+    def abort_repair(self):
+        reaper, args = ReaperCLI.prepare_reaper(
+            "abort-repair",
+            "Abort a repair run.",
+            extra_arguments=_arguments_for_abort_repair
+        )
+        print "# Aborting a repair run with id: {0}".format(args.run_id)
+        reaper.put("repair_run/{0}".format(args.run_id), state="ABORTED")
+        print "# Repair run '{0}' aborted".format(args.run_id)
 
     def start_schedule(self):
         reaper, args = ReaperCLI.prepare_reaper(

--- a/src/main/java/com/spotify/reaper/core/RepairRun.java
+++ b/src/main/java/com/spotify/reaper/core/RepairRun.java
@@ -140,6 +140,7 @@ public class RepairRun implements Comparable<RepairRun> {
     ERROR,
     DONE,
     PAUSED,
+    ABORTED,
     DELETED
   }
 

--- a/src/main/java/com/spotify/reaper/resources/RepairRunResource.java
+++ b/src/main/java/com/spotify/reaper/resources/RepairRunResource.java
@@ -265,6 +265,8 @@ public class RepairRunResource {
       return pauseRun(repairRun.get(), repairUnit.get(), segmentsRepaired);
     } else if (isResuming(oldState, newState)) {
       return resumeRun(repairRun.get(), repairUnit.get(), segmentsRepaired);
+    } else if (isAborting(oldState, newState)) {
+      return abortRun(repairRun.get(), repairUnit.get(), segmentsRepaired);
     } else {
       String errMsg = String.format("Transition %s->%s not supported.", oldState.toString(),
                                     newState.toString());
@@ -285,6 +287,10 @@ public class RepairRunResource {
     return oldState == RepairRun.RunState.PAUSED && newState == RepairRun.RunState.RUNNING;
   }
 
+  private boolean isAborting(RepairRun.RunState oldState, RepairRun.RunState newState) {
+    return oldState != RepairRun.RunState.ERROR && newState == RepairRun.RunState.ABORTED;
+  }
+
   private Response startRun(RepairRun repairRun, RepairUnit repairUnit, int segmentsRepaired) {
     LOG.info("Starting run {}", repairRun.getId());
     RepairRun newRun = context.repairManager.startRepairRun(context, repairRun);
@@ -302,6 +308,12 @@ public class RepairRunResource {
   private Response resumeRun(RepairRun repairRun, RepairUnit repairUnit, int segmentsRepaired) {
     LOG.info("Resuming run {}", repairRun.getId());
     RepairRun newRun = context.repairManager.startRepairRun(context, repairRun);
+    return Response.ok().entity(new RepairRunStatus(newRun, repairUnit, segmentsRepaired)).build();
+  }
+
+  private Response abortRun(RepairRun repairRun, RepairUnit repairUnit, int segmentsRepaired) {
+    LOG.info("Aborting run {}", repairRun.getId());
+    RepairRun newRun = context.repairManager.abortRepairRun(context, repairRun);
     return Response.ok().entity(new RepairRunStatus(newRun, repairUnit, segmentsRepaired)).build();
   }
 

--- a/src/main/java/com/spotify/reaper/resources/view/RepairRunStatus.java
+++ b/src/main/java/com/spotify/reaper/resources/view/RepairRunStatus.java
@@ -125,7 +125,8 @@ public class RepairRunStatus {
     if (startTime == null || endTime != null) {
       estimatedTimeOfArrival = null;
     } else {
-      if (state == RepairRun.RunState.ERROR || state == RepairRun.RunState.DELETED) {
+      if (state == RepairRun.RunState.ERROR || state == RepairRun.RunState.DELETED ||
+          state == RepairRun.RunState.ABORTED ) {
         estimatedTimeOfArrival = null;
       } else if (segmentsRepaired == 0) {
         estimatedTimeOfArrival = null;

--- a/src/main/java/com/spotify/reaper/service/RepairManager.java
+++ b/src/main/java/com/spotify/reaper/service/RepairManager.java
@@ -142,6 +142,17 @@ public class RepairManager {
     return updatedRun;
   }
 
+  public RepairRun abortRepairRun(AppContext context, RepairRun runToBeAborted) {
+    RepairRun updatedRun = runToBeAborted.with()
+      .runState(RepairRun.RunState.ABORTED)
+      .pauseTime(DateTime.now())
+      .build(runToBeAborted.getId());
+    if (!context.storage.updateRepairRun(updatedRun)) {
+      throw new RuntimeException("failed updating repair run " + updatedRun.getId());
+    }
+    return updatedRun;
+  }
+
   public void scheduleRetry(RepairRunner runner) {
     executor.schedule(runner, retryDelayMillis, TimeUnit.MILLISECONDS);
   }


### PR DESCRIPTION
This change also removes run/schedule deletion endpoints. This is according to a recent talk
we had about never deleting anything because of bookeeping.