### PR TITLE
Syncronize all get&update operations of RepairRun objects

### DIFF
--- a/src/main/java/com/spotify/reaper/core/RepairRun.java
+++ b/src/main/java/com/spotify/reaper/core/RepairRun.java
@@ -146,6 +146,10 @@ public class RepairRun implements Comparable<RepairRun> {
     public boolean isActive() {
       return this == RUNNING || this == PAUSED;
     }
+
+    public boolean isTerminated() {
+      return this == DONE || this == ERROR || this == ABORTED || this == DELETED;
+    }
   }
 
   public static class Builder {

--- a/src/main/java/com/spotify/reaper/service/RepairRunner.java
+++ b/src/main/java/com/spotify/reaper/service/RepairRunner.java
@@ -347,9 +347,14 @@ public class RepairRunner implements Runnable {
   public void updateLastEvent(String newEvent) {
     synchronized (this) {
       RepairRun repairRun = context.storage.getRepairRun(repairRunId).get();
-      context.storage.updateRepairRun(repairRun.with()
-          .lastEvent(newEvent)
-          .build(repairRunId));
+      if (repairRun.getRunState().isTerminated()) {
+        LOG.warn("Will not update lastEvent of run that has already terminated. The message was: "
+            + "\"{}\"", newEvent);
+      } else {
+        context.storage.updateRepairRun(repairRun.with()
+            .lastEvent(newEvent)
+            .build(repairRunId));
+      }
     }
   }
 }

--- a/src/test/java/com/spotify/reaper/unit/service/SegmentRunnerTest.java
+++ b/src/test/java/com/spotify/reaper/unit/service/SegmentRunnerTest.java
@@ -25,6 +25,7 @@ import com.spotify.reaper.cassandra.RepairStatusHandler;
 import com.spotify.reaper.core.RepairRun;
 import com.spotify.reaper.core.RepairSegment;
 import com.spotify.reaper.core.RepairUnit;
+import com.spotify.reaper.service.RepairRunner;
 import com.spotify.reaper.service.RingRange;
 import com.spotify.reaper.service.SegmentRunner;
 import com.spotify.reaper.storage.IStorage;
@@ -69,7 +70,7 @@ public class SegmentRunnerTest {
         new RepairUnit.Builder("reaper", "reaper", Sets.newHashSet("reaper")));
     RepairRun run = context.storage.addRepairRun(
         new RepairRun.Builder("reaper", cf.getId(), DateTime.now(), 0.5, 1,
-                              RepairParallelism.PARALLEL));
+            RepairParallelism.PARALLEL));
     context.storage.addRepairSegments(Collections.singleton(
         new RepairSegment.Builder(run.getId(), new RingRange(BigInteger.ONE, BigInteger.ZERO),
                                   cf.getId())), run.getId());
@@ -110,7 +111,9 @@ public class SegmentRunnerTest {
         return jmx;
       }
     };
-    SegmentRunner sr = new SegmentRunner(context, segmentId, Collections.singleton(""), 100, 0.5, "reaper");
+    RepairRunner rr = mock(RepairRunner.class);
+    SegmentRunner sr = new SegmentRunner(context, segmentId, Collections.singleton(""), 100, 0.5,
+        RepairParallelism.PARALLEL, "reaper", rr);
     sr.run();
 
     future.getValue().get();
@@ -182,7 +185,9 @@ public class SegmentRunnerTest {
         return jmx;
       }
     };
-    SegmentRunner sr = new SegmentRunner(context, segmentId, Collections.singleton(""), 1000, 0.5, "reaper");
+    RepairRunner rr = mock(RepairRunner.class);
+    SegmentRunner sr = new SegmentRunner(context, segmentId, Collections.singleton(""), 1000, 0.5,
+        RepairParallelism.PARALLEL, "reaper", rr);
     sr.run();
 
     future.getValue().get();
@@ -252,7 +257,9 @@ public class SegmentRunnerTest {
         return jmx;
       }
     };
-    SegmentRunner sr = new SegmentRunner(context, segmentId, Collections.singleton(""), 1000, 0.5, "reaper");
+    RepairRunner rr = mock(RepairRunner.class);
+    SegmentRunner sr = new SegmentRunner(context, segmentId, Collections.singleton(""), 1000, 0.5,
+        RepairParallelism.PARALLEL, "reaper", rr);
     sr.run();
 
     future.getValue().get();


### PR DESCRIPTION
Now that RepairRunner spawns multiple threads to repair segments in
parallel, modifications to the RepairRun has to be syncronized. This
was overlooked and led to some misbehavior.

For example consider threads A and B repair the same RepairRun. A wants
to update the "lastEvent" field of the run, so it gets the run from
storage. Now B runs into a problem and puts the run in ERROR state.
Only then, A modifies the "lastEvent" field and sends the updated run
to storage. Then the run will go from ERROR to RUNNING, and we have
some sort of zombie repair run.

This is now fixed on the RepairRunner and SegmentRunner levels. But
requests to the RepairRunResource may still cause this to happen if
timing is bad.