### PR TITLE
Remove daysToExpireAfterDone

### DIFF
--- a/resource/cassandra-reaper.yaml
+++ b/resource/cassandra-reaper.yaml
@@ -6,7 +6,6 @@ segmentCount: 200
 repairParallelism: DATACENTER_AWARE
 repairIntensity: 0.9
 scheduleDaysBetween: 7
-daysToExpireAfterDone: 2
 repairRunThreadCount: 15
 hangingRepairTimeoutMins: 30
 storageType: memory


### PR DESCRIPTION
This field raises the following error during a check: `Unrecognized field at: daysToExpireAfterDone`

```
$ java -jar ./cassandra-reaper-0.2.4-SNAPSHOT.jar check ./resource/cassandra-reaper.yaml 
./cassandra-reaper.yaml has an error:
  * Unrecognized field at: daysToExpireAfterDone
    Did you mean?:
      - dataSourceFactory
      - storageType
      - server
      - repairIntensity
      - database
        [10 more]
```
