### PR TITLE
Add support for access control via Apache shiro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Build products and artifacts
-*.html
 .m2-repository/
 pom.xml.versionsBackup
 target/

--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ The Reaper service specific configuration values are:
   Optional setting which you can set to be "true", if you wish to enable the CORS headers
   for running an external GUI application, like [this project](https://github.com/spodkowinski/cassandra-reaper-ui).
 
+* accessControl
+
+  Optional setting to enable access control for REST service endpoints based on Apache Shiro.
+  When used, additional `/login` and `/logout` endpoints are made available to allow session management.
+  All the access control is driven exclusively from the `shiro.ini` configuration. 
+  Its location can be specified via `shiro:iniConfigs`.
+  An example `shiro.ini` configuration file can be found from within this project repository:
+  *src/test/resources/shiro.ini*
+  
 Notice that in the *server* section of the configuration, if you want to bind the service
 to all interfaces, use value "0.0.0.0", or just leave the *bindHost* line away completely.
 Using "*" as bind value won't work.
@@ -262,6 +271,19 @@ Source code for all the REST resources can be found from package com.spotify.rea
     Repair schedule will get deleted only if there are no associated repair runs for the schedule.
     Delete all the related repair runs before calling this endpoint.
 
+## Login Resource
+
+* POST     /login
+  * Expected form parameters:
+      * *username*: username
+      * *password*: password
+  * Performs the authentication based on the `shiro` configuration and creates the session when successful
+  * Returns an error when password combination is not valid
+
+* POST     /logout
+  * Expected query parameters: *None*
+  * Invalidates the current session
+  
 
 Doing a Release (on this repository)
 ------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,21 @@
             <artifactId>guava</artifactId>
             <version>18.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.secnod.dropwizard</groupId>
+            <artifactId>dropwizard-shiro</artifactId>
+            <version>0.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.6.1</version>
+        </dependency>
 
         <!--test scope-->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>0.7.1</dropwizard.version>
+        <dropwizard.version>0.9.3</dropwizard.version>
         <cassandra.version>2.0.12</cassandra.version>
         <cucumber.version>1.1.5</cucumber.version>
     </properties>
@@ -54,6 +54,16 @@
             <artifactId>postgresql</artifactId>
             <version>9.3-1100-jdbc41</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
 
         <!--test scope-->
         <dependency>
@@ -84,6 +94,12 @@
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-junit</artifactId>
             <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert-core</artifactId>
+            <version>2.0M10</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/spotify/reaper/ReaperApplication.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplication.java
@@ -28,6 +28,8 @@ import com.spotify.reaper.storage.IStorage;
 import com.spotify.reaper.storage.MemoryStorage;
 import com.spotify.reaper.storage.PostgresStorage;
 
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.joda.time.DateTimeZone;
@@ -87,6 +89,12 @@ public class ReaperApplication extends Application<ReaperApplicationConfiguratio
   @Override
   public void initialize(Bootstrap<ReaperApplicationConfiguration> bootstrap) {
     bootstrap.addBundle(new AssetsBundle("/assets/", "/webui", "index.html"));
+    bootstrap.setConfigurationSourceProvider(
+            new SubstitutingSourceProvider(
+                    bootstrap.getConfigurationSourceProvider(),
+                    new EnvironmentVariableSubstitutor()
+            )
+    );
   }
 
   @Override

--- a/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.hibernate.validator.constraints.NotEmpty;
 
+import java.time.Duration;
 import java.util.Map;
 
 import javax.validation.Valid;
@@ -28,6 +29,7 @@ import javax.ws.rs.DefaultValue;
 
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
+import org.secnod.dropwizard.shiro.ShiroConfiguration;
 
 public class ReaperApplicationConfiguration extends Configuration {
 
@@ -74,6 +76,8 @@ public class ReaperApplicationConfiguration extends Configuration {
   @JsonProperty
   private JmxCredentials jmxAuth;
 
+  @JsonProperty
+  private AccessControlConfiguration accessControl;
 
   public int getSegmentCount() {
     return segmentCount;
@@ -168,6 +172,17 @@ public class ReaperApplicationConfiguration extends Configuration {
     this.jmxAuth = jmxAuth;
   }
 
+  public AccessControlConfiguration getAccessControl() {
+    return accessControl;
+  }
+
+  public void setAccessControl(AccessControlConfiguration accessControl) {
+    this.accessControl = accessControl;
+  }
+
+  public boolean isAccessControlEnabled() {
+    return getAccessControl() != null;
+  }
   public static class JmxCredentials {
 
     @JsonProperty
@@ -183,6 +198,22 @@ public class ReaperApplicationConfiguration extends Configuration {
       return password;
     }
 
+  }
+
+  public static class AccessControlConfiguration {
+
+    @JsonProperty
+    private ShiroConfiguration shiro;
+    @JsonProperty
+    private Duration sessionTimeout;
+
+    public ShiroConfiguration getShiroConfiguration() {
+      return shiro;
+    }
+
+    public Duration getSessionTimeout() {
+      return sessionTimeout;
+    }
   }
 
 }

--- a/src/main/java/com/spotify/reaper/resources/LoginResource.java
+++ b/src/main/java/com/spotify/reaper/resources/LoginResource.java
@@ -1,0 +1,42 @@
+package com.spotify.reaper.resources;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.IncorrectCredentialsException;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.subject.Subject;
+import org.secnod.shiro.jaxrs.Auth;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import java.io.IOException;
+
+@Path("/")
+public class LoginResource {
+
+  @Path("/login")
+  @POST
+  public void login(@FormParam("username") String username, @FormParam("password") String password, @Auth Subject subject) throws IOException {
+    ensurePresent(username, "Invalid credentials: missing username.");
+    ensurePresent(password, "Invalid credentials: missing password.");
+
+    try {
+      subject.login(new UsernamePasswordToken(username, password));
+    } catch (AuthenticationException e) {
+      throw new IncorrectCredentialsException("Invalid credentials combination for user: " + username);
+    }
+  }
+
+  @Path("/logout")
+  @POST
+  public void logout(@Auth Subject subject) throws IOException {
+    subject.logout();
+  }
+
+  private void ensurePresent(String value, String message) {
+    if (StringUtils.isBlank(value)) {
+      throw new IncorrectCredentialsException(message);
+    }
+  }
+}

--- a/src/main/java/com/spotify/reaper/resources/auth/ShiroExceptionMapper.java
+++ b/src/main/java/com/spotify/reaper/resources/auth/ShiroExceptionMapper.java
@@ -1,0 +1,31 @@
+package com.spotify.reaper.resources.auth;
+
+import org.apache.shiro.ShiroException;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authz.AuthorizationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import static java.lang.String.format;
+
+@Provider
+public class ShiroExceptionMapper implements ExceptionMapper<ShiroException> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ShiroExceptionMapper.class);
+
+  @Override
+  public Response toResponse(ShiroException exception) {
+    if (AuthorizationException.class.isAssignableFrom(exception.getClass())
+        || AuthenticationException.class.isAssignableFrom(exception.getClass())) {
+      LOG.info("Authentication failed", exception);
+      return Response.status(Response.Status.FORBIDDEN).entity(exception.getMessage()).build();
+    }
+
+    LOG.error("Unexpected ShiroException", exception);
+    return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+  }
+}

--- a/src/main/java/com/spotify/reaper/resources/view/RepairRunStatus.java
+++ b/src/main/java/com/spotify/reaper/resources/view/RepairRunStatus.java
@@ -20,7 +20,7 @@ import com.spotify.reaper.core.RepairUnit;
 import com.spotify.reaper.resources.CommonTools;
 
 import org.apache.cassandra.repair.RepairParallelism;
-import org.apache.commons.lang.time.DurationFormatUtils;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.format.ISODateTimeFormat;

--- a/src/main/java/com/spotify/reaper/storage/PostgresStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/PostgresStorage.java
@@ -64,7 +64,7 @@ public class PostgresStorage implements IStorage {
     try {
       final DBIFactory factory = new DBIFactory();
       jdbi = factory.build(environment, config.getDataSourceFactory(), "postgresql");
-    } catch (ClassNotFoundException ex) {
+    } catch (RuntimeException ex) {
       LOG.error("failed creating database connection: {}", ex);
       throw new ReaperException(ex);
     }

--- a/src/test/java/com/spotify/reaper/SimpleReaperClient.java
+++ b/src/test/java/com/spotify/reaper/SimpleReaperClient.java
@@ -27,8 +27,6 @@ public class SimpleReaperClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(SimpleReaperClient.class);
 
-  private static Optional<Map<String, String>> EMPTY_PARAMS = Optional.absent();
-
   public static Response doHttpCall(String httpMethod, String host, int port, String urlPath,
                                     Optional<Map<String, String>> params) {
     String reaperBase = "http://" + host.toLowerCase() + ":" + port + "/";
@@ -100,9 +98,9 @@ public class SimpleReaperClient {
     this.reaperPort = reaperPort;
   }
 
-  public List<RepairScheduleStatus> getRepairSchedulesForCluster(String clusterName) {
+  public List<RepairScheduleStatus> getRepairSchedulesForCluster(String clusterName, Optional<Map<String, String>> params) {
     Response response = doHttpCall("GET", reaperHost, reaperPort,
-            "/repair_schedule/cluster/" + clusterName, EMPTY_PARAMS);
+            "/repair_schedule/cluster/" + clusterName, params);
     assertEquals(200, response.getStatus());
     String responseData = response.readEntity(String.class);
     return parseRepairScheduleStatusListJSON(responseData);

--- a/src/test/java/com/spotify/reaper/acceptance/BasicSteps.java
+++ b/src/test/java/com/spotify/reaper/acceptance/BasicSteps.java
@@ -4,33 +4,26 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
 import com.spotify.reaper.AppContext;
-import com.spotify.reaper.ReaperException;
 import com.spotify.reaper.SimpleReaperClient;
 import com.spotify.reaper.cassandra.JmxConnectionFactory;
 import com.spotify.reaper.cassandra.JmxProxy;
 import com.spotify.reaper.resources.CommonTools;
 import com.spotify.reaper.resources.view.RepairRunStatus;
 import com.spotify.reaper.resources.view.RepairScheduleStatus;
-import com.sun.jersey.api.client.ClientResponse;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.math.BigInteger;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.ws.rs.core.Response;
-
-import cucumber.api.PendingException;
 import cucumber.api.java.Before;
 import cucumber.api.java.en.And;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -80,8 +73,8 @@ public class BasicSteps {
   public void callAndExpect(String httpMethod, String callPath,
                             Optional<Map<String, String>> params, Response.Status expectedStatus,
                             Optional<String> expectedDataInResponseData) {
-    ClientResponse response = ReaperTestJettyRunner.callReaper(httpMethod, callPath, params);
-    String responseData = response.getEntity(String.class);
+    Response response = ReaperTestJettyRunner.callReaper(httpMethod, callPath, params);
+    String responseData = response.readEntity(String.class);
     LOG.info("Got response data: " + responseData);
     assertEquals(expectedStatus.getStatusCode(), response.getStatus());
     if (expectedDataInResponseData.isPresent()) {
@@ -155,10 +148,10 @@ public class BasicSteps {
     params.put("owner", TestContext.TEST_USER);
     params.put("intensity", "0.9");
     params.put("scheduleDaysBetween", "1");
-    ClientResponse response =
+    Response response =
         ReaperTestJettyRunner.callReaper("POST", "/repair_schedule", Optional.of(params));
     assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-    String responseData = response.getEntity(String.class);
+    String responseData = response.readEntity(String.class);
     RepairScheduleStatus schedule = SimpleReaperClient.parseRepairScheduleStatusJSON(responseData);
     TestContext.LAST_MODIFIED_ID = schedule.getId();
   }
@@ -181,10 +174,10 @@ public class BasicSteps {
     params.put("owner", TestContext.TEST_USER);
     params.put("intensity", "0.8");
     params.put("scheduleDaysBetween", "1");
-    ClientResponse response =
+    Response response =
         ReaperTestJettyRunner.callReaper("POST", "/repair_schedule", Optional.of(params));
     assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-    String responseData = response.getEntity(String.class);
+    String responseData = response.readEntity(String.class);
     RepairScheduleStatus schedule = SimpleReaperClient.parseRepairScheduleStatusJSON(responseData);
     TestContext.LAST_MODIFIED_ID = schedule.getId();
   }
@@ -240,10 +233,10 @@ public class BasicSteps {
     params.put("clusterName", clusterName);
     params.put("keyspace", keyspace);
     params.put("owner", TestContext.TEST_USER);
-    ClientResponse response =
+    Response response =
         ReaperTestJettyRunner.callReaper("POST", "/repair_run", Optional.of(params));
     assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-    String responseData = response.getEntity(String.class);
+    String responseData = response.readEntity(String.class);
     RepairRunStatus run = SimpleReaperClient.parseRepairRunStatusJSON(responseData);
     TestContext.LAST_MODIFIED_ID = run.getId();
   }
@@ -251,11 +244,11 @@ public class BasicSteps {
   @Then("^reaper has (\\d+) repairs for cluster called \"([^\"]*)\"$")
   public void reaper_has_repairs_for_cluster_called(int runAmount, String clusterName)
       throws Throwable {
-    ClientResponse response =
+    Response response =
         ReaperTestJettyRunner.callReaper("GET", "/repair_run/cluster/" + clusterName,
                                          EMPTY_PARAMS);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    String responseData = response.getEntity(String.class);
+    String responseData = response.readEntity(String.class);
     List<RepairRunStatus> runs = SimpleReaperClient.parseRepairRunStatusListJSON(responseData);
     assertEquals(runAmount, runs.size());
   }

--- a/src/test/java/com/spotify/reaper/acceptance/ReaperTestJettyRunner.java
+++ b/src/test/java/com/spotify/reaper/acceptance/ReaperTestJettyRunner.java
@@ -9,7 +9,6 @@ import com.spotify.reaper.AppContext;
 import com.spotify.reaper.ReaperApplication;
 import com.spotify.reaper.ReaperApplicationConfiguration;
 import com.spotify.reaper.SimpleReaperClient;
-import com.sun.jersey.api.client.ClientResponse;
 
 import net.sourceforge.argparse4j.inf.Namespace;
 
@@ -18,12 +17,15 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URLDecoder;
 import java.util.Map;
 
 import io.dropwizard.cli.ServerCommand;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+
+import javax.ws.rs.core.Response;
 
 /**
  * Simple Reaper application runner for testing purposes.
@@ -39,7 +41,7 @@ public class ReaperTestJettyRunner {
 
   public static void setup(AppContext testContext) throws Exception {
     if (runnerInstance == null) {
-      String testConfigPath = Resources.getResource("cassandra-reaper-at.yaml").getPath();
+      String testConfigPath = URLDecoder.decode(Resources.getResource("cassandra-reaper-at.yaml").getPath(), "UTF-8");
       LOG.info("initializing ReaperTestJettyRunner with config in path: " + testConfigPath);
       runnerInstance = new ReaperTestJettyRunner(testConfigPath, testContext);
       runnerInstance.start();
@@ -55,8 +57,8 @@ public class ReaperTestJettyRunner {
     }
   }
 
-  public static ClientResponse callReaper(String httpMethod, String urlPath,
-                                          Optional<Map<String, String>> params) {
+  public static Response callReaper(String httpMethod, String urlPath,
+                                    Optional<Map<String, String>> params) {
     assert runnerInstance != null : "service not initialized, call setup() first";
     return SimpleReaperClient.doHttpCall(httpMethod, "localhost", runnerInstance.getLocalPort(),
                                          urlPath, params);

--- a/src/test/java/com/spotify/reaper/acceptance/ReaperTestJettyRunner.java
+++ b/src/test/java/com/spotify/reaper/acceptance/ReaperTestJettyRunner.java
@@ -17,6 +17,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Map;
 
@@ -39,9 +40,28 @@ public class ReaperTestJettyRunner {
   private static ReaperTestJettyRunner runnerInstance;
   private static SimpleReaperClient reaperClientInstance;
 
+  public enum ConfigResource {
+    DEFAULT("cassandra-reaper-at.yaml"),
+    ACCESS_CONTROL_ENABLED("cassandra-reaper-at-access-control-enabled.yaml");
+
+    private final String resource;
+
+    ConfigResource(String resource) {
+      this.resource = resource;
+    }
+
+    public String getResourcePath() throws UnsupportedEncodingException {
+      return URLDecoder.decode(Resources.getResource(resource).getPath(), "UTF-8");
+    }
+  }
+
   public static void setup(AppContext testContext) throws Exception {
+    setup(testContext, ConfigResource.DEFAULT);
+  }
+
+  public static void setup(AppContext testContext, ConfigResource configResource) throws Exception {
     if (runnerInstance == null) {
-      String testConfigPath = URLDecoder.decode(Resources.getResource("cassandra-reaper-at.yaml").getPath(), "UTF-8");
+      String testConfigPath = configResource.getResourcePath();
       LOG.info("initializing ReaperTestJettyRunner with config in path: " + testConfigPath);
       runnerInstance = new ReaperTestJettyRunner(testConfigPath, testContext);
       runnerInstance.start();

--- a/src/test/resources/assets/login.html
+++ b/src/test/resources/assets/login.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Not a real login page</title>
+</head>
+<body>
+
+<!-- Used for testing redirection to login page -->
+
+</body>
+</html>

--- a/src/test/resources/cassandra-reaper-at-access-control-enabled.yaml
+++ b/src/test/resources/cassandra-reaper-at-access-control-enabled.yaml
@@ -1,0 +1,72 @@
+# Cassandra Reaper Configuration for Acceptance Tests.
+#
+segmentCount: 200
+repairParallelism: SEQUENTIAL
+repairIntensity: 0.95
+scheduleDaysBetween: 7
+repairRunThreadCount: 15
+hangingRepairTimeoutMins: 1
+storageType: memory
+
+logging:
+  level: DEBUG
+  loggers:
+    io.dropwizard: INFO
+    org.eclipse.jetty: INFO
+  appenders:
+    - type: console
+
+server:
+  type: default
+  applicationConnectors:
+    - type: http
+      port: 8083
+      bindHost: 127.0.0.1
+  adminConnectors:
+    - type: http
+      port: 8084
+      bindHost: 127.0.0.1
+
+# database section will be ignored if storageType is set to "memory"
+database:
+  # the name of your JDBC driver
+  driverClass: org.postgresql.Driver
+
+  # the username
+  user: reaper-user
+
+  # the password
+  password: reaper-secret
+
+  # the JDBC URL
+  url: jdbc:postgresql://127.0.0.1:5432/reaper_db
+
+  # any properties specific to your JDBC driver:
+  properties:
+    charSet: UTF-8
+
+  # the maximum amount of time to wait on an empty pool before throwing an exception
+  maxWaitForConnection: 1s
+
+  # the SQL query to run when validating a connection's liveness
+  validationQuery: "SELECT 1"
+
+  # the minimum number of connections to keep open
+  minSize: 8
+
+  # the maximum number of connections to keep open
+  maxSize: 32
+
+  # whether or not idle connections should be validated
+  checkConnectionWhileIdle: true
+
+  # the amount of time to sleep between runs of the idle connection validation, abandoned cleaner and idle pool resizing
+  evictionInterval: 10s
+
+  # the minimum amount of time an connection must sit idle in the pool before it is eligible for eviction
+  minIdleTime: 1 minute
+
+accessControl:
+  sessionTimeout: PT30S
+  shiro:
+    iniConfigs: ["classpath:shiro.ini"]

--- a/src/test/resources/cassandra-reaper.yaml
+++ b/src/test/resources/cassandra-reaper.yaml
@@ -97,3 +97,10 @@ database:
 
   # the minimum amount of time an connection must sit idle in the pool before it is eligible for eviction
   minIdleTime: 1 minute
+
+# Enables authentication according to the specified shiro configuration.
+# Remove config block althogether to disable access control
+accessControl:
+  sessionTimeout: PT30S
+  shiro:
+    iniConfigs: ["file:src/test/resources/shiro.ini"]

--- a/src/test/resources/com.spotify.reaper.acceptance/access_control.feature
+++ b/src/test/resources/com.spotify.reaper.acceptance/access_control.feature
@@ -1,0 +1,30 @@
+Feature: Access Control
+
+  Scenario Outline: Request to protected resource is redirected to login page when accessed without login
+    Given a reaper service with access control enabled is running
+    When a <path> <request> is made
+    Then the response was redirected to the login page
+    Examples:
+      | path   | request              |
+      | GET    | /cluster             |
+      | POST   | /cluster             |
+      | GET    | /repair_run          |
+      | GET    | /repair_schedule     |
+
+  Scenario Outline: Request to public resource is allowed without login
+    Given a reaper service with access control enabled is running
+    When a <path> <request> is made
+    Then a "OK" response is returned
+    Examples:
+      | path | request |
+      | GET  | /ping   |
+
+  Scenario Outline: Request to protected resource is allowed when access control is disabled
+    Given a reaper service is running
+    When a <path> <request> is made
+    Then a "OK" response is returned
+    Examples:
+      | path | request |
+      | GET    | /cluster             |
+      | GET    | /repair_run          |
+      | GET    | /repair_schedule     |

--- a/src/test/resources/shiro.ini
+++ b/src/test/resources/shiro.ini
@@ -1,0 +1,15 @@
+[main]
+authc = org.apache.shiro.web.filter.authc.PassThruAuthenticationFilter
+authc.loginUrl = /webui/login.html
+
+[users]
+myuser = mypassword
+
+[urls]
+# Allow anonynous access to login page (and dependencies), but no other pages
+/webui/login.html = anon
+/webui/*.html = authc
+/webui/** = anon
+/ping = anon
+/login = anon
+/** = authc


### PR DESCRIPTION
- that enables access control conditionally. This required upgrading dropwizard and so its jersey api client dependencies.
- when enabled uses shiro.ini file to perform authentication and automatically redirects to login url when a protected resource is accessed without login
- add login and logout endpoint for session management conditionally based on whether accessControl is enabled
- allow session timeout to be configured conditionally too
- end users are meant to provide a shiro.ini config file to define protected resources, users and other authentication logic based on Apache Shiro - an example of shiro.ini is available under test resources
- also based on java8 

Look here for the UI corresponding changes: spodkowinski/cassandra-reaper-ui#1
